### PR TITLE
Vercelビルドエラーを解消する設定更新

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,8 @@
       "src": "frontend/package.json",
       "use": "@vercel/static-build",
       "config": {
-        "distDir": "dist"
+        "distDir": "frontend/dist",
+        "buildCommand": "npm install --prefix frontend && npm run build --prefix frontend"
       }
     }
   ],


### PR DESCRIPTION
## 概要
- Vercelの静的ビルド出力先を `frontend/dist` に修正
- フロントエンドの依存関係をインストールしてビルドするコマンドを追加

## テスト
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d64d1149688333bbe6d32e7c639f11