### PR TITLE
OCRの前処理と日本語フォント自動検出の改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ image-pdf-ocr-suite/
   - [UB Mannheim版インストーラー](https://github.com/UB-Mannheim/tesseract/wiki)が便利です。
   - インストール時に `Additional language data` → `Japanese` を選択し、可能であればシステムPATHへ追加してください。
   - もしコマンドラインから `tesseract -v` が実行できない場合は、環境変数 `TESSERACT_CMD` または `TESSERACT_PATH` に `tesseract.exe`（Windows）や `tesseract` バイナリ（macOS/Linux）のパスを設定してください。
+  - PDF生成時に日本語の文字を埋め込むため、Noto Sans CJKなどの日本語フォントをシステムにインストールしておいてください。特定のフォントを使いたい場合は環境変数 `OCR_JPN_FONT` にフォントファイルへのパスを設定できます。
 
 ## セットアップ
 
@@ -83,6 +84,15 @@ python extract_text_from_pdf.py --pdf_path "入力PDFのパス" --output_path "�
   - コマンドラインから `tesseract -v` が正常に実行できるか確認してください。
   - インストール先が標準パス以外の場合は、環境変数 `TESSERACT_CMD`（または `TESSERACT_PATH`）に実行ファイルのパスを設定してください。GUI/CLIいずれの処理でもこの設定が利用されます。
   - PyInstaller版を配布する際は、`ImagePdfOcr.exe` と同じ階層、もしくは `Tesseract-OCR` フォルダ配下に `tesseract.exe` を同梱することで自動的に認識されます。
+- `ページ処理中に問題が発生しました: need font file or buffer`
+  - 日本語フォントが見つからない場合に表示されます。Noto Sans CJKやIPAexフォントなど日本語対応フォントをインストールし、必要に応じて `OCR_JPN_FONT` 環境変数でフォントファイルのパスを指定してください。
+
+## OCR精度を高めるヒント
+
+- 本アプリは `lang="jpn"` を指定してOCRを実行します。`tessdata` に日本語データが含まれていることを確認してください。
+- 各ページのOCR結果から平均信頼度を算出し、既定値（65%）を下回る場合は自動的に二値化・1.5倍拡大の前処理を行って再OCRします。処理後により高い信頼度が得られた方を採用します。
+- 信頼度の閾値は環境変数 `OCR_CONFIDENCE_THRESHOLD` で調整できます。数値を上げると積極的に前処理を行い、下げると前処理を抑制できます。
+- 画像がぼやけていたり解像度が低い場合は、スキャン時に解像度を300dpi以上に設定する、余白を削除するなどの工夫も効果的です。
 
 ## ライセンス
 

--- a/image_pdf_ocr/ocr.py
+++ b/image_pdf_ocr/ocr.py
@@ -3,19 +3,270 @@
 from __future__ import annotations
 
 import io
+import math
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Union
+from typing import Iterable, Tuple, Union
 
 import fitz  # type: ignore
 import pytesseract
-from PIL import Image
+import pandas as pd
+from PIL import Image, ImageOps
 from shutil import which
 
 
 class OCRConversionError(RuntimeError):
     """OCR変換処理で発生した例外。"""
+_AVERAGE_CONFIDENCE_THRESHOLD = float(os.environ.get("OCR_CONFIDENCE_THRESHOLD", "65"))
+_TEXT_RENDER_CONFIDENCE_THRESHOLD = 50.0
+_UPSCALE_FACTOR = 1.5
+_FONT_PATH_CACHE: Path | None = None
+
+
+@dataclass
+class AdaptiveOCRResult:
+    """OCR結果と判定情報を保持するデータクラス。"""
+
+    frame: pd.DataFrame
+    average_confidence: float
+    image_for_string: Image.Image
+    used_preprocessing: bool
+
+
+def _perform_adaptive_ocr(image: Image.Image) -> AdaptiveOCRResult:
+    """平均信頼度に応じて前処理を適用し、最適なOCR結果を返す。"""
+
+    base_image = image.convert("RGB")
+    base_frame_raw = _image_to_data(base_image)
+    base_average = _compute_average_confidence(base_frame_raw)
+    base_frame = _prepare_frame(base_frame_raw, scale=1.0)
+
+    best_result = AdaptiveOCRResult(
+        frame=base_frame,
+        average_confidence=base_average,
+        image_for_string=base_image,
+        used_preprocessing=False,
+    )
+
+    if base_average >= _AVERAGE_CONFIDENCE_THRESHOLD:
+        return best_result
+
+    preprocessed_image, scale = _preprocess_for_ocr(base_image)
+    processed_frame_raw = _image_to_data(preprocessed_image)
+    processed_average = _compute_average_confidence(processed_frame_raw)
+    processed_frame = _prepare_frame(processed_frame_raw, scale=scale)
+
+    if processed_average > best_result.average_confidence:
+        return AdaptiveOCRResult(
+            frame=processed_frame,
+            average_confidence=processed_average,
+            image_for_string=preprocessed_image,
+            used_preprocessing=True,
+        )
+
+    return best_result
+
+
+def _image_to_data(image: Image.Image) -> pd.DataFrame:
+    """pytesseractを用いてOCR結果をDataFrameで取得する。"""
+
+    return pytesseract.image_to_data(
+        image, lang="jpn", output_type=pytesseract.Output.DATAFRAME
+    )
+
+
+def _compute_average_confidence(frame: pd.DataFrame) -> float:
+    """OCR結果の平均信頼度を算出する。"""
+
+    if "conf" not in frame.columns:
+        return 0.0
+
+    confidences = pd.to_numeric(frame["conf"], errors="coerce")
+    valid = confidences[(confidences.notna()) & (confidences >= 0)]
+
+    if valid.empty:
+        return 0.0
+
+    return float(valid.mean())
+
+
+def _prepare_frame(frame: pd.DataFrame, scale: float) -> pd.DataFrame:
+    """数値列をfloat化し、必要に応じて座標をスケールダウンする。"""
+
+    prepared = frame.copy()
+
+    for column in ("left", "top", "width", "height", "conf"):
+        if column in prepared.columns:
+            prepared[column] = pd.to_numeric(prepared[column], errors="coerce")
+
+    if scale != 1.0:
+        for column in ("left", "top", "width", "height"):
+            if column in prepared.columns:
+                prepared[column] = prepared[column] / scale
+
+    return prepared
+
+
+def _filter_frame_by_confidence(frame: pd.DataFrame, threshold: float) -> pd.DataFrame:
+    """指定した信頼度以上の行だけを残したDataFrameを返す。"""
+
+    if "conf" not in frame.columns:
+        return frame.iloc[0:0]
+
+    confidences = pd.to_numeric(frame["conf"], errors="coerce")
+    mask = confidences >= threshold
+    filtered = frame.loc[mask].copy()
+    filtered["text"] = filtered["text"].fillna("") if "text" in filtered.columns else ""
+    return filtered
+
+
+def _preprocess_for_ocr(image: Image.Image) -> Tuple[Image.Image, float]:
+    """OCR精度向上のための前処理（拡大＋二値化）を適用する。"""
+
+    grayscale = image.convert("L")
+    scale = _UPSCALE_FACTOR
+    if scale != 1.0:
+        new_size = (int(grayscale.width * scale), int(grayscale.height * scale))
+        resized = grayscale.resize(new_size, Image.LANCZOS)
+    else:
+        resized = grayscale
+
+    enhanced = ImageOps.autocontrast(resized)
+    threshold = 180
+    binary = enhanced.point(lambda x: 255 if x > threshold else 0, mode="L")
+    return binary, scale
+
+
+def _extract_coordinates(row: pd.Series) -> Tuple[float | None, float | None, float | None]:
+    """DataFrameの1行から座標情報を抽出する。"""
+
+    try:
+        x = float(row.get("left"))
+        y = float(row.get("top"))
+        h = float(row.get("height"))
+    except (TypeError, ValueError):
+        return None, None, None
+
+    if any(math.isnan(value) for value in (x, y, h)):
+        return None, None, None
+
+    return x, y, h
+
+
+def _find_japanese_font_path() -> Path:
+    """日本語描画可能なフォントファイルを探索して返す。"""
+
+    global _FONT_PATH_CACHE
+
+    if _FONT_PATH_CACHE and _FONT_PATH_CACHE.exists():
+        return _FONT_PATH_CACHE
+
+    env_font = os.environ.get("OCR_JPN_FONT")
+    if env_font:
+        font_path = Path(env_font).expanduser()
+        if font_path.exists():
+            _FONT_PATH_CACHE = font_path
+            return font_path
+
+    candidate_files = [
+        "NotoSansCJK-Regular.ttc",
+        "NotoSansCJKjp-Regular.otf",
+        "NotoSerifCJK-Regular.ttc",
+        "SourceHanSansJP-Regular.otf",
+        "SourceHanSerifJP-Regular.otf",
+        "ipaexg.ttf",
+        "ipaexm.ttf",
+        "ipag.ttf",
+        "ipam.ttf",
+        "YuGothR.ttc",
+        "YuMincho.ttc",
+    ]
+
+    candidate_patterns = [
+        "*NotoSansCJK*.ttc",
+        "*NotoSansCJK*.otf",
+        "*NotoSerifCJK*.ttc",
+        "*NotoSerifCJK*.otf",
+        "*SourceHanSans*.otf",
+        "*SourceHanSerif*.otf",
+        "*ipaex*.ttf",
+        "*ipaex*.otf",
+        "*ipag*.ttf",
+        "*ipag*.ttc",
+        "*ipam*.ttf",
+        "*ipam*.ttc",
+        "*YuGoth*.ttc",
+        "*YuMincho*.ttc",
+    ]
+
+    directories = _candidate_font_directories()
+
+    for directory in directories:
+        for name in candidate_files:
+            path = directory / name
+            if path.exists():
+                _FONT_PATH_CACHE = path
+                return path
+
+    for directory in directories:
+        if not directory.exists():
+            continue
+        for pattern in candidate_patterns:
+            matches = sorted(directory.rglob(pattern))
+            for match in matches:
+                if match.is_file():
+                    _FONT_PATH_CACHE = match
+                    return match
+
+    raise OCRConversionError(
+        "日本語フォントが見つかりません。Noto Sans CJKなどのフォントをインストールし、"
+        "環境変数 OCR_JPN_FONT でフォントファイルへのパスを指定してください。"
+    )
+
+
+def _candidate_font_directories() -> list[Path]:
+    """日本語フォント探索対象となるディレクトリ一覧を返す。"""
+
+    dirs: list[Path] = []
+
+    for env_name in ("OCR_JPN_FONT_DIR", "OCR_FONT_DIR"):
+        env_value = os.environ.get(env_name)
+        if env_value:
+            dirs.append(Path(env_value).expanduser())
+
+    home = Path.home()
+    dirs.extend(
+        [
+            home / ".fonts",
+            home / ".local/share/fonts",
+            Path("/usr/share/fonts"),
+            Path("/usr/local/share/fonts"),
+            Path("/Library/Fonts"),
+            Path("/System/Library/Fonts"),
+            Path("/System/Library/Fonts/Supplemental"),
+            Path("/Library/Application Support/Microsoft/Fonts"),
+        ]
+    )
+
+    module_dir = Path(__file__).resolve().parent
+    dirs.append(module_dir)
+    dirs.append(module_dir / "fonts")
+
+    if os.name == "nt":
+        windir = Path(os.environ.get("WINDIR", "C:/Windows"))
+        dirs.append(windir / "Fonts")
+
+    seen: dict[Path, None] = {}
+    ordered_dirs: list[Path] = []
+    for directory in dirs:
+        resolved = directory.resolve()
+        if resolved not in seen:
+            seen[resolved] = None
+            ordered_dirs.append(resolved)
+
+    return ordered_dirs
 
 
 def _validate_tesseract_setting() -> bool:
@@ -109,6 +360,8 @@ def create_searchable_pdf(
     if not input_path.exists():
         raise FileNotFoundError(f"入力ファイルが見つかりません: {input_path}")
 
+    font_path = _find_japanese_font_path()
+
     try:
         input_doc = fitz.open(input_path)  # type: ignore[arg-type]
     except Exception as exc:  # pragma: no cover - PyMuPDF例外
@@ -119,24 +372,32 @@ def create_searchable_pdf(
     try:
         for page in input_doc:
             pix = page.get_pixmap(dpi=300)
-            with Image.open(io.BytesIO(pix.tobytes("png"))) as img:
-                ocr_data = pytesseract.image_to_data(
-                    img, lang="jpn", output_type=pytesseract.Output.DATAFRAME
-                )
-            ocr_data = ocr_data[ocr_data.conf > 50]
+            image_bytes = io.BytesIO(pix.tobytes("png"))
+            with Image.open(image_bytes) as pil_image:
+                ocr_result = _perform_adaptive_ocr(pil_image)
+
+            filtered = _filter_frame_by_confidence(
+                ocr_result.frame, _TEXT_RENDER_CONFIDENCE_THRESHOLD
+            )
 
             new_page = output_doc.new_page(width=page.rect.width, height=page.rect.height)
             new_page.insert_image(page.rect, pixmap=pix)
 
-            for _, row in ocr_data.iterrows():
+            for _, row in filtered.iterrows():
                 text = str(row.get("text", "")).strip()
                 if not text:
                     continue
-                x = row.get("left", 0)
-                y = row.get("top", 0)
-                h = row.get("height", 0)
+                x, y, h = _extract_coordinates(row)
+                if x is None or y is None or h is None:
+                    continue
                 try:
-                    new_page.insert_text((x, y + h), text, fontname="cjk", fontsize=h * 0.8, render_mode=3)
+                    new_page.insert_text(
+                        (x, y + h),
+                        text,
+                        fontfile=str(font_path),
+                        fontsize=h * 0.8,
+                        render_mode=3,
+                    )
                 except RuntimeError:
                     # PyMuPDFのフォント描画で稀に失敗するケースがあるため無視
                     continue
@@ -174,8 +435,10 @@ def extract_text_from_image_pdf(input_path: Union[str, os.PathLike]) -> str:
     try:
         for index, page in enumerate(document, start=1):
             pix = page.get_pixmap(dpi=300)
-            with Image.open(io.BytesIO(pix.tobytes("png"))) as image:
-                page_text = pytesseract.image_to_string(image, lang="jpn")
+            image_bytes = io.BytesIO(pix.tobytes("png"))
+            with Image.open(image_bytes) as pil_image:
+                ocr_result = _perform_adaptive_ocr(pil_image)
+                page_text = pytesseract.image_to_string(ocr_result.image_for_string, lang="jpn")
             texts.append(f"--- ページ {index} ---\n{page_text.strip()}\n")
     except Exception as exc:
         raise OCRConversionError(f"テキスト抽出中に問題が発生しました: {exc}") from exc


### PR DESCRIPTION
## 概要
- 日本語フォントファイルを自動探索し、PDF生成時にフォント未検出で失敗しないようにしました
- OCR結果の平均信頼度が閾値を下回った場合に二値化・拡大の前処理を施して再OCRする仕組みを実装しました
- READMEにフォント設定方法とOCR精度改善のヒントを追記しました

## テスト
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d8c3adead0833391ca0a898a7a6fe4