### PR TITLE
進捗表示を固定文言とバー形式に改善

### DIFF
--- a/ocr_desktop_app.py
+++ b/ocr_desktop_app.py
@@ -192,7 +192,11 @@ class OCRDesktopApp:
     def _convert_task(self, input_path: Path, output_path: Path) -> None:
         self._log(f"検索可能PDFを生成中: {output_path}")
         try:
-            create_searchable_pdf(input_path, output_path)
+            create_searchable_pdf(
+                input_path,
+                output_path,
+                progress_callback=self._log,
+            )
         except (FileNotFoundError, OCRConversionError) as exc:
             message = str(exc)
             self._log(f"エラー: {message}")


### PR DESCRIPTION
## 概要
- create_searchable_pdfに進捗コールバックを追加し、任意の出力先へ進捗メッセージを送れるようにしました
- デスクトップアプリから進捗コールバックを渡すことで、推定残り時間をGUIログへ表示するようにしました
- 進捗メッセージを固定文言と20分割の「=」バーで構成し、進捗度合いが視覚的にわかるようにしました

## テスト
- 未実施（GUI環境がないため）

------
https://chatgpt.com/codex/tasks/task_e_68d8c925d7cc83338a3bf8765a13a567