### PR TITLE
テキスト抽出時の進捗表示を改善

### DIFF
--- a/ocr_desktop_app.py
+++ b/ocr_desktop_app.py
@@ -217,7 +217,11 @@ class OCRDesktopApp:
     def _extract_task(self, input_path: Path, output_path: Path) -> None:
         self._log(f"テキストを抽出中: {output_path}")
         try:
-            extract_text_to_file(input_path, output_path)
+            extract_text_to_file(
+                input_path,
+                output_path,
+                progress_callback=self._log,
+            )
         except (FileNotFoundError, OCRConversionError) as exc:
             message = str(exc)
             self._log(f"エラー: {message}")


### PR DESCRIPTION
## 概要
- 進捗メッセージからバー表示を取り除き、完了ページ数と残り推定時間のみを表示するよう変更
- テキスト抽出処理に進捗コールバックを追加し、ページ完了数と残り推定時間を通知
- デスクトップアプリでテキスト抽出時に進捗ログを反映するよう更新

## テスト
- python -m compileall image_pdf_ocr

------
https://chatgpt.com/codex/tasks/task_e_68d8cbfa5d0c8333b4482b3b0e017b80