### PR TITLE
作業数切替とキャンセル機能の追加

### DIFF
--- a/image_pdf_ocr/__init__.py
+++ b/image_pdf_ocr/__init__.py
@@ -5,6 +5,7 @@ from .ocr import (
     extract_text_from_image_pdf,
     extract_text_to_file,
     find_and_set_tesseract_path,
+    OCRCancelledError,
     OCRConversionError,
 )
 
@@ -13,5 +14,6 @@ __all__ = [
     "extract_text_from_image_pdf",
     "extract_text_to_file",
     "find_and_set_tesseract_path",
+    "OCRCancelledError",
     "OCRConversionError",
 ]


### PR DESCRIPTION
## 概要
- OCR処理関数にキャンセルイベントを追加し、途中停止時の例外を整備しました
- GUIにキャンセルボタンと作業数セレクトボックスを設置し、1画面/2画面の切替と並列操作に対応させました
- ワークスペースごとにログや進捗を管理するクラスを新設し、UI例外時の通知処理を調整しました

## テスト
- python -m compileall image_pdf_ocr ocr_desktop_app.py

------
https://chatgpt.com/codex/tasks/task_e_68d8d027c418833385792230c8899b2c