### PR TITLE
PDFパスワード解除タブの追加

### DIFF
--- a/image_pdf_ocr/__init__.py
+++ b/image_pdf_ocr/__init__.py
@@ -7,6 +7,8 @@ from .ocr import (
     find_and_set_tesseract_path,
     OCRCancelledError,
     OCRConversionError,
+    PDFPasswordRemovalError,
+    remove_pdf_password,
 )
 
 __all__ = [
@@ -16,4 +18,6 @@ __all__ = [
     "find_and_set_tesseract_path",
     "OCRCancelledError",
     "OCRConversionError",
+    "PDFPasswordRemovalError",
+    "remove_pdf_password",
 ]

--- a/ocr_desktop_app.py
+++ b/ocr_desktop_app.py
@@ -13,8 +13,10 @@ from tkinter.scrolledtext import ScrolledText
 from image_pdf_ocr import (
     OCRCancelledError,
     OCRConversionError,
+    PDFPasswordRemovalError,
     create_searchable_pdf,
     extract_text_to_file,
+    remove_pdf_password,
 )
 
 
@@ -22,7 +24,6 @@ class ProcessingWorkspace:
     """単一のOCR処理画面を構築・管理する。"""
 
     def __init__(self, app: "OCRDesktopApp", parent: tk.Widget) -> None:
-        self.app = app
         self.root = app.master
         self.frame = tk.Frame(parent)
 
@@ -398,6 +399,198 @@ class ProcessingWorkspace:
         self.log_widget.configure(state=tk.DISABLED)
 
 
+class PDFPasswordRemovalWorkspace:
+    """PDFのパスワード解除画面を構築・管理する。"""
+
+    def __init__(self, app: "OCRDesktopApp", parent: tk.Widget) -> None:
+        self.root = app.master
+        self.frame = tk.Frame(parent)
+
+        self.input_path = tk.StringVar()
+        self.output_path = tk.StringVar()
+        self.password = tk.StringVar()
+        self.status_var = tk.StringVar(value="準備完了")
+
+        self.remove_btn: tk.Button | None = None
+        self.progress: ttk.Progressbar | None = None
+
+        self._worker: threading.Thread | None = None
+
+        self._create_widgets()
+
+    def pack(self, *, fill: str, expand: bool, padx: tuple[int, int], pady: tuple[int, int]) -> None:
+        self.frame.pack(fill=fill, expand=expand, padx=padx, pady=pady)
+
+    def _create_widgets(self) -> None:
+        input_frame = tk.LabelFrame(self.frame, text="入力PDF")
+        input_frame.pack(fill=tk.X, padx=12, pady=(12, 6))
+
+        input_entry = tk.Entry(input_frame, textvariable=self.input_path)
+        input_entry.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=(12, 6), pady=8)
+
+        browse_input_btn = tk.Button(
+            input_frame, text="参照", width=10, command=self._select_input_file
+        )
+        browse_input_btn.pack(side=tk.LEFT, padx=(0, 12), pady=8)
+
+        password_frame = tk.LabelFrame(self.frame, text="PDFパスワード")
+        password_frame.pack(fill=tk.X, padx=12, pady=6)
+
+        password_label = tk.Label(password_frame, text="パスワードを入力してください。")
+        password_label.pack(anchor=tk.W, padx=12, pady=(8, 0))
+
+        password_entry = tk.Entry(password_frame, textvariable=self.password, show="*")
+        password_entry.pack(fill=tk.X, padx=12, pady=(4, 8))
+
+        output_frame = tk.LabelFrame(self.frame, text="パスワード解除後の保存先")
+        output_frame.pack(fill=tk.X, padx=12, pady=6)
+
+        output_entry = tk.Entry(output_frame, textvariable=self.output_path)
+        output_entry.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=(12, 6), pady=8)
+
+        browse_output_btn = tk.Button(
+            output_frame, text="保存先", width=10, command=self._select_output_file
+        )
+        browse_output_btn.pack(side=tk.LEFT, padx=(0, 12), pady=8)
+
+        button_frame = tk.Frame(self.frame)
+        button_frame.pack(fill=tk.X, padx=12, pady=(6, 0))
+
+        self.remove_btn = tk.Button(
+            button_frame, text="パスワードを解除", command=self._start_removal
+        )
+        self.remove_btn.pack(side=tk.LEFT, padx=(0, 6))
+
+        status_frame = tk.Frame(self.frame)
+        status_frame.pack(fill=tk.X, padx=12, pady=(12, 12))
+
+        self.progress = ttk.Progressbar(status_frame, mode="indeterminate")
+        self.progress.pack(side=tk.LEFT, padx=(0, 12), pady=4)
+
+        status_label = tk.Label(status_frame, textvariable=self.status_var, anchor=tk.W)
+        status_label.pack(side=tk.LEFT, fill=tk.X, expand=True)
+
+    def _select_input_file(self) -> None:
+        file_path = filedialog.askopenfilename(
+            title="パスワード付きPDFを選択",
+            filetypes=(("PDF", "*.pdf"), ("すべてのファイル", "*.*")),
+        )
+        if file_path:
+            self.input_path.set(file_path)
+            self._suggest_output_path(Path(file_path))
+
+    def _select_output_file(self) -> None:
+        current = self.output_path.get()
+        default = Path(current) if current else None
+        initialdir = default.parent if default else None
+        initialfile = default.name if default else None
+        file_path = filedialog.asksaveasfilename(
+            title="パスワード解除後のPDFの保存先",
+            defaultextension=".pdf",
+            initialdir=initialdir,
+            initialfile=initialfile,
+            filetypes=(("PDF", "*.pdf"),),
+        )
+        if file_path:
+            self.output_path.set(file_path)
+
+    def _start_removal(self) -> None:
+        if self._worker and self._worker.is_alive():
+            return
+
+        input_value = self.input_path.get().strip()
+        if not input_value:
+            self._show_error("入力PDFを選択してください。")
+            return
+        input_path = Path(input_value)
+        if not input_path.exists():
+            self._show_error("指定された入力PDFが見つかりません。")
+            return
+
+        output_value = self.output_path.get().strip()
+        if not output_value:
+            self._show_error("保存先を指定してください。")
+            return
+        output_path = Path(output_value)
+        if output_path.suffix.lower() != ".pdf":
+            self._show_error("保存先には.pdf拡張子を指定してください。")
+            return
+
+        password = self.password.get()
+        if not password:
+            self._show_error("パスワードを入力してください。")
+            return
+
+        self._set_busy(True)
+        self._update_status("パスワードを解除しています…")
+        self._run_in_thread(
+            lambda: self._remove_task(
+                input_path=input_path, output_path=output_path, password=password
+            )
+        )
+
+    def _run_in_thread(self, target: Callable[[], None]) -> None:
+        def wrapper() -> None:
+            try:
+                target()
+            finally:
+                self._worker = None
+                self._notify(lambda: self._set_busy(False))
+
+        self._worker = threading.Thread(target=wrapper, daemon=True)
+        self._worker.start()
+
+    def _remove_task(self, input_path: Path, output_path: Path, password: str) -> None:
+        try:
+            remove_pdf_password(input_path, output_path, password)
+        except (FileNotFoundError, ValueError, PDFPasswordRemovalError) as exc:
+            message = str(exc)
+            self._notify(lambda msg=message: self._handle_failure(msg))
+        except Exception as exc:  # noqa: BLE001
+            message = f"予期しないエラーが発生しました: {exc}"
+            self._notify(lambda msg=message: self._handle_failure(msg))
+        else:
+            self._notify(
+                lambda: (
+                    messagebox.showinfo(
+                        "完了", f"パスワードを解除したPDFを保存しました:\n{output_path}"
+                    ),
+                    self._update_status("パスワードの解除が完了しました。"),
+                )
+            )
+
+    def _handle_failure(self, message: str) -> None:
+        self._show_error(message)
+        self._update_status("エラーが発生しました。内容を確認してください。")
+
+    def _set_busy(self, busy: bool) -> None:
+        if not self.remove_btn or not self.progress:
+            return
+        state = tk.DISABLED if busy else tk.NORMAL
+        self.remove_btn.configure(state=state)
+        if busy:
+            self.progress.start(10)
+        else:
+            self.progress.stop()
+
+    def _update_status(self, message: str) -> None:
+        self.status_var.set(message)
+
+    def _notify(self, callback: Callable[[], None]) -> None:
+        def safe_callback() -> None:
+            if self.frame.winfo_exists():
+                callback()
+
+        self.root.after(0, safe_callback)
+
+    def _show_error(self, message: str) -> None:
+        messagebox.showerror("エラー", message)
+
+    def _suggest_output_path(self, input_path: Path) -> None:
+        if not self.output_path.get():
+            self.output_path.set(str(input_path.with_name(f"{input_path.stem}_unlocked.pdf")))
+
+
 class OCRDesktopApp:
     """画像PDFを処理する簡易デスクトップアプリケーション。"""
 
@@ -412,12 +605,24 @@ class OCRDesktopApp:
 
         self.mode_var = tk.StringVar(value="1つの作業")
         self.workspaces: list[ProcessingWorkspace] = []
+        self.current_workspace_count = 1
+
+        self.notebook: ttk.Notebook | None = None
+        self.ocr_tab: tk.Frame | None = None
+        self.password_tab: tk.Frame | None = None
+        self.password_workspace: PDFPasswordRemovalWorkspace | None = None
 
         self._create_widgets()
         self._rebuild_workspaces(1)
 
     def _create_widgets(self) -> None:
-        control_frame = tk.Frame(self.master)
+        self.notebook = ttk.Notebook(self.master)
+        self.notebook.pack(fill=tk.BOTH, expand=True)
+
+        self.ocr_tab = tk.Frame(self.notebook)
+        self.notebook.add(self.ocr_tab, text="OCR処理")
+
+        control_frame = tk.Frame(self.ocr_tab)
         control_frame.pack(fill=tk.X, padx=12, pady=(12, 0))
 
         mode_label = tk.Label(control_frame, text="同時に処理する作業数:")
@@ -433,8 +638,18 @@ class OCRDesktopApp:
         mode_combo.pack(side=tk.LEFT, padx=(8, 0))
         mode_combo.bind("<<ComboboxSelected>>", lambda _event: self._on_mode_change())
 
-        self.workspace_container = tk.Frame(self.master)
+        self.workspace_container = tk.Frame(self.ocr_tab)
         self.workspace_container.pack(fill=tk.BOTH, expand=True)
+
+        self.password_tab = tk.Frame(self.notebook)
+        self.notebook.add(self.password_tab, text="PDFパスワード解除")
+
+        self.password_workspace = PDFPasswordRemovalWorkspace(self, self.password_tab)
+        self.password_workspace.pack(
+            fill=tk.BOTH, expand=True, padx=(12, 12), pady=(12, 12)
+        )
+
+        self.notebook.bind("<<NotebookTabChanged>>", self._on_tab_changed)
 
     def _on_mode_change(self) -> None:
         count = 2 if self.mode_var.get().startswith("2") else 1
@@ -449,10 +664,9 @@ class OCRDesktopApp:
         for child in self.workspace_container.winfo_children():
             child.destroy()
 
-        if count == 2:
-            self.master.geometry(self.double_geometry)
-        else:
-            self.master.geometry(self.single_geometry)
+        self.current_workspace_count = count
+        if self._is_ocr_tab_selected():
+            self._apply_geometry(count)
 
         for index in range(count):
             workspace = ProcessingWorkspace(self, self.workspace_container)
@@ -471,6 +685,23 @@ class OCRDesktopApp:
             workspace._log(message)
             workspace._update_status("UIで予期しないエラーが発生しました。ログをご確認ください。")
         messagebox.showerror("UIエラー", "予期しないUIエラーが発生しました。ログを確認してください。")
+
+    def _on_tab_changed(self, _event: object | None = None) -> None:
+        if self._is_ocr_tab_selected():
+            self._apply_geometry(self.current_workspace_count)
+        else:
+            self.master.geometry(self.single_geometry)
+
+    def _apply_geometry(self, count: int) -> None:
+        if count >= 2:
+            self.master.geometry(self.double_geometry)
+        else:
+            self.master.geometry(self.single_geometry)
+
+    def _is_ocr_tab_selected(self) -> bool:
+        if not self.notebook or not self.ocr_tab:
+            return True
+        return self.notebook.select() == str(self.ocr_tab)
 
 
 def main() -> None:


### PR DESCRIPTION
## 概要
- OCRデスクトップアプリにPDFパスワード解除用のタブと画面を追加しました
- PyMuPDFを利用してパスワード解除済みPDFを出力するユーティリティを実装し、エラー種別を整理しました

## テスト
- python -m compileall image_pdf_ocr ocr_desktop_app.py

------
https://chatgpt.com/codex/tasks/task_e_68d8e012fc848333925ecb220f00ad12